### PR TITLE
AIV 64b SaveSystem Task End

### DIFF
--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scenes/Vertical/Mapping/Game.unity
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scenes/Vertical/Mapping/Game.unity
@@ -17464,27 +17464,27 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 6627870495776338433, guid: d4edaa89b0c04d844b62af85caecac68, type: 3}
       propertyPath: m_Size.x
-      value: 1.468689
+      value: 5.981186
       objectReference: {fileID: 0}
     - target: {fileID: 6627870495776338433, guid: d4edaa89b0c04d844b62af85caecac68, type: 3}
       propertyPath: m_Size.y
-      value: 0.43986583
+      value: 4.717375
       objectReference: {fileID: 0}
     - target: {fileID: 6627870495776338433, guid: d4edaa89b0c04d844b62af85caecac68, type: 3}
       propertyPath: m_Size.z
-      value: 1.5239029
+      value: 3.7096596
       objectReference: {fileID: 0}
     - target: {fileID: 6627870495776338433, guid: d4edaa89b0c04d844b62af85caecac68, type: 3}
       propertyPath: m_Center.x
-      value: -0.02268982
+      value: 0.06591797
       objectReference: {fileID: 0}
     - target: {fileID: 6627870495776338433, guid: d4edaa89b0c04d844b62af85caecac68, type: 3}
       propertyPath: m_Center.y
-      value: -0.63171995
+      value: 1.5070345
       objectReference: {fileID: 0}
     - target: {fileID: 6627870495776338433, guid: d4edaa89b0c04d844b62af85caecac68, type: 3}
       propertyPath: m_Center.z
-      value: -0.26195145
+      value: -0.37327385
       objectReference: {fileID: 0}
     - target: {fileID: 8176420364829841870, guid: d4edaa89b0c04d844b62af85caecac68, type: 3}
       propertyPath: m_LocalPosition.x
@@ -17492,7 +17492,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8176420364829841870, guid: d4edaa89b0c04d844b62af85caecac68, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.435
+      value: 2.41
       objectReference: {fileID: 0}
     - target: {fileID: 8176420364829841870, guid: d4edaa89b0c04d844b62af85caecac68, type: 3}
       propertyPath: m_LocalPosition.z
@@ -24793,6 +24793,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6957428097568221196, guid: f633759523d6a2b4ab28d3157b9e7f30, type: 3}
+      propertyPath: collectibleID
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -27836,8 +27840,28 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3687626849501495596, guid: 6f21fa7bb86f4c1478d50d5a2931b2f3, type: 3}
+      insertIndex: 6
+      addedObject: {fileID: 1368029333}
   m_SourcePrefab: {fileID: 100100000, guid: 6f21fa7bb86f4c1478d50d5a2931b2f3, type: 3}
+--- !u!1 &1368029332 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3687626849501495596, guid: 6f21fa7bb86f4c1478d50d5a2931b2f3, type: 3}
+  m_PrefabInstance: {fileID: 1368029331}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1368029333
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1368029332}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1829cc73727a18b4c8374202c89a2639, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &1370173474 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 488906, guid: d159be490db85e240abcb56be8535d5b, type: 3}

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Characters/CharacterSpawner/CharacterSpawner.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Characters/CharacterSpawner/CharacterSpawner.cs
@@ -122,6 +122,7 @@ public class CharacterSpawner : MonoBehaviour, IPoolRequester
             ) ;
 
             obj.transform.position = navMeshSpawnHit.position;
+            characterToSpawn.CalculateUnpossessability();
 
             obj.SetActive(true);
             activeEnemies++;

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Characters/Characters/EnemyChar.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Characters/Characters/EnemyChar.cs
@@ -272,6 +272,10 @@ public abstract class EnemyChar : MonoBehaviour
 
         CalculateDamage();
 
+    }
+
+    public void CalculateUnpossessability()
+    {
         // Unpossessable EnemyChar behavior
         ObjectByProbability<bool> unpossessableProb = new ObjectByProbability<bool>();
         unpossessableProb.Max = characterStartingInfo.CharStats.UnpossessableProbability;

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Characters/PlayerState/Component/PlayerStateHealth.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Characters/PlayerState/Component/PlayerStateHealth.cs
@@ -44,7 +44,9 @@ public class PlayerStateHealth : MonoBehaviour
 
     public static void SetGameLoaded(EventArgs message)
     {
-        gameLoaded = true;
+        bool toLoad;
+        EventArgsFactory.LoadGameEndedParser(message, out toLoad);
+        gameLoaded = toLoad;
     }
 
     #region Mono

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Enviroment/Interactable/AlienObject.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Enviroment/Interactable/AlienObject.cs
@@ -8,10 +8,13 @@ public class AlienObject : InteractableBase, ICollectable
     #region SerializeFields
     [SerializeField]
     private uint alienObjectID;    // Use this for saving
+    [SerializeField] 
+    public uint CollectibleID => alienObjectID;
     #endregion
 
     #region Variables
     PlayerStateMission missionController;
+
     #endregion
 
     #region Callback
@@ -39,11 +42,11 @@ public class AlienObject : InteractableBase, ICollectable
 
     protected override void OnOpen()
     {
+        SaveSystem.ActiveGameData.PlayerSavedData.UnlockCollectible((int)alienObjectID);
+        SaveSystem.SaveGameStats(PlayerState.Get().CurrentPlayer.transform.position);
+
         GlobalEventSystem.CastEvent(EventName.StartDialogue, EventArgsFactory.StartDialogueFactory(alienObjectID, 0));
         UnscribeInteract();
-
-        SaveSystem.ActiveGameData.PlayerSavedData.UnlockCollectible((int)alienObjectID);
-        
         Collect();
     }
 

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Enviroment/Interactable/Chest.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Enviroment/Interactable/Chest.cs
@@ -8,10 +8,14 @@ public class Chest : InteractableBase, ICollectable
     #region SerializeFields
     [SerializeField]
     private uint dialogueID;
+    [SerializeField]
+    public uint collectibleID;
     #endregion
+    public uint CollectibleID => collectibleID;
 
     #region Variables
     PlayerStateMission missionController;
+
     #endregion
 
     #region Callback
@@ -29,9 +33,13 @@ public class Chest : InteractableBase, ICollectable
     #region OverrideBaseClass
     protected override void OnOpen()
     {
+
         GlobalEventSystem.CastEvent(EventName.StartDialogue, EventArgsFactory.StartDialogueFactory(dialogueID, 0));
         UnscribeInteract();
         Collect();
+
+        SaveSystem.ActiveGameData.PlayerSavedData.UnlockCollectible((int)collectibleID);
+        SaveSystem.SaveGameStats(PlayerState.Get().CurrentPlayer.transform.position);
     }
 
     public void Collect()
@@ -52,6 +60,14 @@ public class Chest : InteractableBase, ICollectable
     {
         missionController = PlayerState.Get().MissionController;
         AddMission();
+    }
+
+    private void Start()
+    {
+        if (SaveSystem.ActiveGameData.PlayerSavedData.IsCollectibleUnlocked((int)collectibleID))
+        {
+            Collect();
+        }
     }
     #endregion
 }

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Enviroment/Interactable/InteractableBase.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Enviroment/Interactable/InteractableBase.cs
@@ -44,6 +44,7 @@ public abstract class InteractableBase : MonoBehaviour
         controller.OnInteractPerformed -= OnOpen;
     }
     protected abstract void OnOpen();
+
     protected void InternalOnTriggerEnter(Collider other, bool status)
     {
         if(!CanOpen(other)) return;

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/SaveSystem/Checkpoint.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/SaveSystem/Checkpoint.cs
@@ -9,31 +9,20 @@ public class Checkpoint : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
-        #region Save: PlayerGeneralParameters
-        SaveSystem.ActiveGameData.PlayerSavedData.UpdateLastCheckpointPosition(transform.position + spawnPositionOffset);
-        SaveSystem.ActiveGameData.PlayerSavedData.UpdatePlayerStats(PlayerState.Get().InformationController.GetStats());
-        SaveSystem.ActiveGameData.PlayerSavedData.UpdatePlayerLevel(PlayerState.Get().LevelController.GetLevelStruct());
-        #endregion
-
-        #region Save: EnemyCharInfo
-        GameObject player = PlayerState.Get().CurrentPlayer;
-        EnemyChar playerChar = player.GetComponentInChildren<EnemyChar>();
-        EnemyInfo playerInfo = playerChar.CharacterInfo;
-        SaveSystem.ActiveGameData.PlayerSavedData.UpdatePlayerCharInfo(playerInfo);
-        #endregion
-
-        #region Save: PlayerHealth
-        SaveSystem.ActiveGameData.PlayerSavedData.UpdatePlayerHealth(PlayerState.Get().HealthController.GetCurrentHealth());
-        SaveSystem.ActiveGameData.PlayerSavedData.UpdatePlayerMaxHealth(PlayerState.Get().HealthController.GetMaxHealth());
-        #endregion
-
-        SaveSystem.SaveActiveGameData();
+        SaveSystem.SaveGameStats(transform.position + spawnPositionOffset);
         gameObject.SetActive(false);
     }
-
+    private void OnTriggerStay(Collider other)
+    {
+        SaveSystem.SaveGameStats(transform.position + spawnPositionOffset);
+        gameObject.SetActive(false);
+    }
     private void OnDrawGizmosSelected()
     {
         Gizmos.color = Color.yellow;
         Gizmos.DrawWireSphere(transform.position + spawnPositionOffset, offsetSphereRadius);
     }
+
+ 
+
 }

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/SaveSystem/Loading/StaticLoading.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/SaveSystem/Loading/StaticLoading.cs
@@ -8,9 +8,21 @@ public static class StaticLoading
 {
     
     public static bool LoadSaveGame {get; set;}
-    static StaticLoading()
+    //static StaticLoading()
+    //{
+    //    SceneManager.sceneLoaded += OnSceneLoaded;
+    //}
+
+    public static void ManageSceneLoading(bool LoadingActivation)
     {
-        SceneManager.sceneLoaded += OnSceneLoaded;
+        if(LoadingActivation) 
+        { 
+            SceneManager.sceneLoaded += OnSceneLoaded;
+            LoadSaveGame = true;
+            return;
+        }
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+        LoadSaveGame = false;
     }
 
     static void OnSceneLoaded(Scene scene, LoadSceneMode mode)
@@ -20,7 +32,7 @@ public static class StaticLoading
 
         if (LoadSaveGame)
         {
-            GlobalEventSystem.CastEvent(EventName.LoadGameEnded, EventArgsFactory.LoadGameEndedFactory());
+            GlobalEventSystem.CastEvent(EventName.LoadGameEnded, EventArgsFactory.LoadGameEndedFactory(true));
             
             // To refactor 
             CharacterSpawner.GetInstance().LoadPlayerCharacter(
@@ -33,5 +45,7 @@ public static class StaticLoading
                 );;
             
         }
+
+        ManageSceneLoading(false);
     }
 }

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/SaveSystem/PlatformSaveSystem/ISaveSystem.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/SaveSystem/PlatformSaveSystem/ISaveSystem.cs
@@ -19,6 +19,7 @@ public interface ISaveSystem
     void LoadSlotData(int slotIndex);
     void LoadAllSlotData();
     void SaveActiveGameData();
+    void SaveGameParams(Vector3 spawnPosition);
 
     void DeleteGameData(int slotIndex);
     void SelectGameData(int slotIndex);

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/SaveSystem/PlatformSaveSystem/StandaloneSaveSystem.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/SaveSystem/PlatformSaveSystem/StandaloneSaveSystem.cs
@@ -53,6 +53,7 @@ public class StandAloneSaveSystem : ISaveSystem
 
     public void DeleteGameData(int slotIndex)
     {
+        LoadSlotData(slotIndex);
         DeleteISaveableData<GameSavedData>(SaveSystemConfiguration.GetGameDataPath(slotIndex), allDatas[slotIndex]);
     }
 
@@ -183,6 +184,30 @@ public class StandAloneSaveSystem : ISaveSystem
         File.Delete(path);
     }
 
+    public void SaveGameParams(Vector3 spawnPosition)
+    {
+        #region Save: PlayerGeneralParameters
+        SaveSystem.ActiveGameData.PlayerSavedData.UpdateLastCheckpointPosition(spawnPosition);
+        SaveSystem.ActiveGameData.PlayerSavedData.UpdatePlayerStats(PlayerState.Get().InformationController.GetStats());
+        SaveSystem.ActiveGameData.PlayerSavedData.UpdatePlayerLevel(PlayerState.Get().LevelController.GetLevelStruct());
+        #endregion
+
+        #region Save: EnemyCharInfo
+        GameObject player = PlayerState.Get().CurrentPlayer;
+        EnemyChar playerChar = player.GetComponentInChildren<EnemyChar>();
+        EnemyInfo playerInfo = playerChar.CharacterInfo;
+        SaveSystem.ActiveGameData.PlayerSavedData.UpdatePlayerCharInfo(playerInfo);
+        #endregion
+
+        #region Save: PlayerHealth
+        SaveSystem.ActiveGameData.PlayerSavedData.UpdatePlayerHealth(PlayerState.Get().HealthController.GetCurrentHealth());
+        SaveSystem.ActiveGameData.PlayerSavedData.UpdatePlayerMaxHealth(PlayerState.Get().HealthController.GetMaxHealth());
+        #endregion
+
+        SaveSystem.SaveActiveGameData();
+    }
+
     #endregion
+
 
 }

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/SaveSystem/SaveSystem.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/SaveSystem/SaveSystem.cs
@@ -85,5 +85,8 @@ public static class SaveSystem
 
     #endregion
 
-
+    public static void SaveGameStats(Vector3 spawnPosition)
+    {
+        platformBasedSaveSystem.SaveGameParams(spawnPosition);
+    }
 }

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/UI/Menu/MainMenu/Controls/UI_MainMenu.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/UI/Menu/MainMenu/Controls/UI_MainMenu.cs
@@ -46,6 +46,7 @@ public class UI_MainMenu : MonoBehaviour
         AudioManager.Get().PlayOneShot("ButtonHover", "UI");
     }
 
+    #region LoadGame
     private void OnContinueGameButtonClicked()
     {
         AudioManager.Get().PlayOneShot("ButtonClick", "UI");
@@ -65,26 +66,28 @@ public class UI_MainMenu : MonoBehaviour
 
         // Load datas from disk to code
         SaveSystem.LoadSlotData(0);
+
+        StaticLoading.ManageSceneLoading(true);
+
         while (!asyncOperation.isDone && loadingBar != null)
         {
             float progress = asyncOperation.progress;
             loadingBar.value = progress;
             loadingBar.title = $"{progress}%";
             yield return new WaitForEndOfFrame();
-        } 
-
-        StaticLoading.LoadSaveGame = true;
+        }
 
         yield return null;
     }
+    #endregion
 
     #region NewGame
     private void OnNewGameButtonClicked() {
         AudioManager.Get().PlayOneShot("ButtonClick", "UI");
-        StartCoroutine(ChangeLevelCoroutine(1));
+        StartCoroutine(StartLevelCoroutine(1));
     }
 
-    IEnumerator ChangeLevelCoroutine(int sceneToLoad) {
+    IEnumerator StartLevelCoroutine(int sceneToLoad) {
         var menuContainer = rootVisualElement.Q<VisualElement>("MenuContainer");
         menuContainer.style.display = DisplayStyle.None;
         var loadingContainer = rootVisualElement.Q<VisualElement>("LoadingContainer");
@@ -96,15 +99,22 @@ public class UI_MainMenu : MonoBehaviour
         InputManager.EnableUIMap(false);
         //yield return new WaitForSeconds(1);
 
+        if (sceneToLoad == 1)
+        {
+            if (SaveSystem.GameDataExists(0))
+                SaveSystem.DeleteGameData(0);
+        
+            SaveSystem.CreateGameData(0);
+            StaticLoading.ManageSceneLoading(false);
+        }
+        GlobalEventSystem.CastEvent(EventName.LoadGameEnded, EventArgsFactory.LoadGameEndedFactory(false));
+
+
         while (!asyncOperation.isDone && loadingBar != null) {
             float progress = asyncOperation.progress;
             loadingBar.value = progress;
             loadingBar.title = $"{progress}%";
             yield return new WaitForEndOfFrame();
-        }
-        if(sceneToLoad == 1)
-        {
-            SaveSystem.CreateGameData(0);
         }
 
         yield return null;
@@ -115,7 +125,7 @@ public class UI_MainMenu : MonoBehaviour
     private void OnTutorialButtonClicked()
     {
         AudioManager.Get().PlayOneShot("ButtonClick", "UI");
-        StartCoroutine(ChangeLevelCoroutine(2));
+        StartCoroutine(StartLevelCoroutine(2));
     }
 
     #endregion

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Utilities/GlobalEventManager/EventArgsFactory.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Utilities/GlobalEventManager/EventArgsFactory.cs
@@ -255,15 +255,17 @@ namespace NotserializableEventManager
         #endregion
 
         #region 
-        public static EventArgs LoadGameEndedFactory()
+        public static EventArgs LoadGameEndedFactory(bool loaded)
         {
             EventArgs message = new EventArgs();
+            message.variables = new object[1];
+            message.variables[0] = loaded;
             return message;
         }
 
-        public static void LoadGameEndedParser(EventArgs message)
+        public static void LoadGameEndedParser(EventArgs message, out bool loaded)
         {
-
+            loaded = (bool)message.variables[0];
         }
 
         #endregion

--- a/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Utilities/Interfaces/ICollectable.cs
+++ b/Flesh-Invader/Assets/AIV_FleshInvader/Scripts/Utilities/Interfaces/ICollectable.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public interface ICollectable
 {
+    uint CollectibleID { get; }
     void AddMission();
     void Collect();
 }

--- a/Flesh-Invader/Assets/Plugins/FMOD/Resources/FMODStudioSettings.asset
+++ b/Flesh-Invader/Assets/Plugins/FMOD/Resources/FMODStudioSettings.asset
@@ -417,8 +417,10 @@ MonoBehaviour:
   switchSettingsMigration: 1
   HasSourceProject: 1
   HasPlatforms: 1
-  sourceProjectPath: C:/Users/Fabri/Desktop/FleshInvader/FleshInvader.fspro
-  sourceBankPath: C:/Users/Fabri/Desktop/FleshInvader/Build
+  sourceProjectPath: C:/Users/Asus/Desktop/Informatica/Videogame Programming/Unity/Esame
+    Finale Unity/FleshInvader/FleshInvader.fspro
+  sourceBankPath: C:/Users/Asus/Desktop/Informatica/Videogame Programming/Unity/Esame
+    Finale Unity/FleshInvader/Build
   sourceBankPathUnformatted: 
   BankRefreshCooldown: 5
   ShowBankRefreshWindow: 1

--- a/Flesh-Invader/Assets/Plugins/FMOD/platforms/win/lib/x86/fmodstudioL.dll.meta
+++ b/Flesh-Invader/Assets/Plugins/FMOD/platforms/win/lib/x86/fmodstudioL.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f666667d9adbe0e4b8d8dd194437b75a
+guid: 2a6098473da0e0449a7a14d2cc054643
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Flesh-Invader/Assets/Plugins/FMOD/platforms/win/lib/x86_64/fmodstudioL.dll.meta
+++ b/Flesh-Invader/Assets/Plugins/FMOD/platforms/win/lib/x86_64/fmodstudioL.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f0c3d7f9411c3ce40bba927665042e71
+guid: 5432f0ff1c1c07142a5c2dbfbca2f88f
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -22,12 +22,11 @@ PluginImporter:
       enabled: 1
       settings:
         CPU: x86_64
-        DefaultValueInitialized: true
         OS: Windows
   - first:
       Standalone: Win64
     second:
-      enabled: 0
+      enabled: 1
       settings: {}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
ADD:
• Collectible id for chest and general ICollectable objects

CHANGE:
• SavingParams in savesystem, checkpoints now call savesystem.SaveGameStats • Now is the characterSpawner the one who calculate if an enemy is unpossessable

FIX:
• UI now updates collectibles found
• On new game the old save is deleted
• Various fix on main menu buttons logic for loading • Now the loadGameEnded global event has a parameter used to know when the game doesn't has to load, but instead to start from the beginning